### PR TITLE
reversed order in norm_by_quarter

### DIFF
--- a/examples/fit_kepler37.py
+++ b/examples/fit_kepler37.py
@@ -17,9 +17,9 @@ def med_filt(x, y, dt=4.):
 
 def norm_by_quarter(flux,ferr,quarter):
     for i in np.unique(quarter):
-        flux[quarter == i] /= np.median(
-            flux[quarter == i])
         ferr[quarter == i] /= np.median(
+            flux[quarter == i])
+        flux[quarter == i] /= np.median(
             flux[quarter == i])
     return flux, ferr
 


### PR DESCRIPTION
In the function `norm_by_quarter`, the order of first median normalizing the `flux`, then median normalizing the `ferr` results in dividing the `ferr` by exactly 1.0.  If you reverse the order and first normalize `ferr` by the median of `flux` -- then normalize `flux` by the median of `flux` -- then the `ferr` is properly normalized, which effects the weights inside the fitting procedure.